### PR TITLE
Temporarily disable star mode

### DIFF
--- a/lm_local_chat/lib/feature_flags.dart
+++ b/lm_local_chat/lib/feature_flags.dart
@@ -1,0 +1,13 @@
+/// Centralised feature toggles for the application.
+///
+/// Feature flags let us enable or disable larger areas of functionality
+/// without having to touch individual call sites each time.
+class FeatureFlags {
+  const FeatureFlags._();
+
+  /// Controls the availability of the "star" experience.
+  ///
+  /// When disabled the UI hides star specific entry points and any persisted
+  /// preferences that refer to it fall back to the default orbit mode.
+  static const bool starModeEnabled = false;
+}


### PR DESCRIPTION
## Summary
- add a FeatureFlags helper and turn the star experience off by default
- make settings fall back to orbit mode when star is unavailable and update persisted preferences
- disable the star toggle in the chat header and update the connection reminder copy accordingly

## Testing
- flutter analyze
- flutter test
- flutter build apk --release *(fails: Android SDK is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccde321b008324b0d67d5bc4c200be